### PR TITLE
imprive public id parsing

### DIFF
--- a/src/Misc/Curiosity.Tools/CHANGELOG.md
+++ b/src/Misc/Curiosity.Tools/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.5.2]
+
+### Changed
+
+- `PublicId.ToPublicId()` returns 17 chars string instead 16 chars
+- `PublicId.TryParse()` can parse hex and dec line
+
 ## [1.5.1] - 2023-11-28
 
 ### Fixed

--- a/src/Misc/Curiosity.Tools/Curiosity.Tools.csproj
+++ b/src/Misc/Curiosity.Tools/Curiosity.Tools.csproj
@@ -12,7 +12,7 @@
 
         <AssemblyVersion>1.0.0</AssemblyVersion>
         <FileVersion>1.0.0</FileVersion>
-        <PackageVersion>1.5.1</PackageVersion>
+        <PackageVersion>1.5.2</PackageVersion>
 
         <Authors>Max Markelow (@markeli), Andrey Ioch (@DevCorvette)</Authors>
         <Company>SIIS Ltd</Company>

--- a/src/Misc/Curiosity.Tools/UniqueId/PublicId.cs
+++ b/src/Misc/Curiosity.Tools/UniqueId/PublicId.cs
@@ -15,20 +15,51 @@ namespace Curiosity.Tools
         /// <returns>ID in HEX</returns>
         public static string ToPublicId(this long id)
         {
-            return id.ToString("x16", CultureInfo.InvariantCulture);
+            // number 17 in the format indicates the minimum number of characters in the string
+            // missing characters are replaced with 0
+            // by the first 0, we can detect that the number is hexadecimal, even if all numbers are there
+            // until 2024 year, our UniqueIdGenerator had generated 16 characters string
+            return id.ToString("x17", CultureInfo.InvariantCulture);
         }
 
         /// <summary>
         /// Converts an ID from a "public" view to a regular long.
         /// </summary>
-        /// <param name= "exportId" >Public version of the ID (only in hex format)</param>
+        /// <param name= "exportId" >String number can be hex or dec</param>
         /// <param name= "id" >Our regular ID</param>
         /// <returns>Successfully parted?</returns>
         public static bool TryParse(string exportId, out long id)
         {
             id = 0;
-            return !String.IsNullOrWhiteSpace(exportId) && 
-                   long.TryParse(exportId, NumberStyles.HexNumber, CultureInfo.InvariantCulture, out id);
+            if (String.IsNullOrWhiteSpace(exportId))
+                return false;
+
+            // try parse as hex or dec
+            return IsHexFormat(exportId)
+                ? long.TryParse(exportId, NumberStyles.HexNumber, CultureInfo.InvariantCulture, out id)
+                : long.TryParse(exportId, out id);
+        }
+
+        /// <summary>
+        /// Detects that line format is hex or dec
+        /// </summary>
+        private static bool IsHexFormat(string line)
+        {
+            // hex when contains non numeric symbols
+            for (var i = 0; i < line.Length; i++)
+            {
+                if (!char.IsDigit(line[i]))
+                    return true;
+            }
+        
+            // until 2024 year, our UniqueIdGenerator had generated 16 chars string then 17 chars
+            // always with first 0
+            if ((line.Length == 16 || line.Length == 17) && 
+                line[0] == '0')
+                return true;
+
+            // exactly dec
+            return false;
         }
     }
 }

--- a/src/Misc/Curiosity.Tools/UniqueId/UniqueIdGenerator.cs
+++ b/src/Misc/Curiosity.Tools/UniqueId/UniqueIdGenerator.cs
@@ -24,6 +24,8 @@ namespace Curiosity.Tools
         private const int MaxSequenceId = 4096;
 
         // 13 apr 2020 (in Ticks / 10000)
+        // can generate positive long numbers ~70 years from this date,
+        // then a overflow starts
         private const long ModelStartEpoch = 63722332800000;
         private static long _generatorId = -1;
 

--- a/tests/UnitTests/Misc/Curiosity.Tools.UnitTests/UniqueId/PublicIdTests.cs
+++ b/tests/UnitTests/Misc/Curiosity.Tools.UnitTests/UniqueId/PublicIdTests.cs
@@ -1,0 +1,56 @@
+﻿using FluentAssertions;
+using Xunit;
+
+namespace Curiosity.Tools.UnitTests.UniqueId
+{
+    public class PublicIdTests
+    {
+        // can detect that line is 16 chars hex and parse it to true long value
+        [Fact]
+        public void TryParse_Parse16CharsHexLine_LongValue()
+        {
+            // arrange
+            const long value = 10752219502637056;
+            const string hex = "0026331630007000"; // 16 chars hex
+            
+            // act
+            var canParse = PublicId.TryParse(hex, out var id);
+
+            // assert
+            canParse.Should().Be(true);
+            id.Should().Be(value);
+        }
+        
+        // can detect that line is 17 chars hex and parse it to true long value
+        [Fact]
+        public void TryParse_Parse17CharsHexLine_LongValue()
+        {
+            // arrange
+            const long value = 10752219502637056;
+            const string hex = "00026331630007000"; // 17 chars hex
+            
+            // act
+            var canParse = PublicId.TryParse(hex, out var id);
+
+            // assert
+            canParse.Should().Be(true);
+            id.Should().Be(value);
+        }
+        
+        // can detect that line is dec and parse it to true long value
+        [Fact]
+        public void TryParse_ParseDecLine_LongValue()
+        {
+            // arrange
+            const long value = 10752219502637056;
+            const string dec = "10752219502637056"; // dec line
+            
+            // act
+            var canParse = PublicId.TryParse(dec, out var id);
+
+            // assert
+            canParse.Should().Be(true);
+            id.Should().Be(value);
+        }
+    }
+}


### PR DESCRIPTION
- метод `PublicId.ToPublicId()` теперь возвращает строку из 17 символов, вместо 16
- метод `PublicId.TryParse()` тперь модет распарсить hex и dec строку
- добавил комменты и тесты